### PR TITLE
Bugs

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -139,6 +139,7 @@ minetest.register_chatcommand("setwarp", {
 	description = "Set a warp location to the players location",
 	privs = { warp_admin = true },
 	func = function(name, param)
+		param = param:gsub("%W", "")
 		local h = "created"
 		for i = 1,table.getn(warps) do
 			if warps[i].name == param then

--- a/init.lua
+++ b/init.lua
@@ -46,15 +46,17 @@ do_warp_queue = function()
 	local t = minetest.get_us_time()
 	for i = table.getn(warps_queue),1,-1 do
 		local e = warps_queue[i]
-		if e.p:getpos().x == e.pos.x and e.p:getpos().y == e.pos.y and e.p:getpos().z == e.pos.z then
-			if t > e.t then
-				warp(e.p, e.w)
+		if e.p:getpos() then
+			if e.p:getpos().x == e.pos.x and e.p:getpos().y == e.pos.y and e.p:getpos().z == e.pos.z then
+				if t > e.t then
+					warp(e.p, e.w)
+					table.remove(warps_queue, i)
+				end
+			else
+				minetest.sound_stop(e.sh)
+				minetest.chat_send_player(e.p:get_player_name(), "You have to stand still for " .. warps_freeze .. " seconds!")
 				table.remove(warps_queue, i)
 			end
-		else
-			minetest.sound_stop(e.sh)
-			minetest.chat_send_player(e.p:get_player_name(), "You have to stand still for " .. warps_freeze .. " seconds!")
-			table.remove(warps_queue, i)
 		end
 	end
 	if table.getn(warps_queue) == 0 then


### PR DESCRIPTION
Fix crashing bug on player leaving server before warp is performed (and after queued), and ensure warp name is without odd characters that can crash the server upon attempting to set the player's POS and receiving nil.